### PR TITLE
Feature/m6 onboarding settings

### DIFF
--- a/Notte/App/DependencyContainer.swift
+++ b/Notte/App/DependencyContainer.swift
@@ -35,4 +35,13 @@ class DependencyContainer: ObservableObject {
             blockRepository: blockRepository
         )
     }
+    
+    func makeExampleDataFactory() -> ExampleDataFactory {
+        ExampleDataFactory(
+            collectionRepository: collectionRepository,
+            pageRepository: pageRepository,
+            nodeRepository: nodeRepository,
+            blockRepository: blockRepository
+        )
+    }
 }

--- a/Notte/App/RootView.swift
+++ b/Notte/App/RootView.swift
@@ -11,13 +11,32 @@ import SwiftUI
 struct RootView: View {
     @StateObject private var router = AppRouter()
     @EnvironmentObject private var dependencyContainer: DependencyContainer
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding: Bool = false
+    @State private var pendingAction: PostOnboardingAction?
+
+    enum PostOnboardingAction { case createFirst, importSamples }
 
     var body: some View {
+        Group {
+            if !hasCompletedOnboarding {
+                OnboardingView(
+                    onCreateFirstCollection: { pendingAction = .createFirst },
+                    onImportSampleData: { pendingAction = .importSamples }
+                )
+            } else {
+                mainNavigation
+            }
+        }
+    }
+
+    private var mainNavigation: some View {
         NavigationStack(path: $router.path) {
             CollectionListScreen(
                 repository: dependencyContainer.collectionRepository,
                 pageRepository: dependencyContainer.pageRepository,
-                nodeRepository: dependencyContainer.nodeRepository
+                nodeRepository: dependencyContainer.nodeRepository,
+                pendingAction: pendingAction,
+                onActionConsumed: { pendingAction = nil }
             )
             .navigationDestination(for: AppRoute.self) { route in
                 switch route {

--- a/Notte/App/RootView.swift
+++ b/Notte/App/RootView.swift
@@ -17,16 +17,19 @@ struct RootView: View {
     enum PostOnboardingAction { case createFirst, importSamples }
 
     var body: some View {
-        Group {
+        ZStack {
             if !hasCompletedOnboarding {
                 OnboardingView(
                     onCreateFirstCollection: { pendingAction = .createFirst },
                     onImportSampleData: { pendingAction = .importSamples }
                 )
+                .transition(.opacity.combined(with: .scale(scale: 1.04)))
             } else {
                 mainNavigation
+                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
             }
         }
+        .animation(.easeInOut(duration: 0.45), value: hasCompletedOnboarding)
     }
 
     private var mainNavigation: some View {

--- a/Notte/App/RootView.swift
+++ b/Notte/App/RootView.swift
@@ -13,6 +13,8 @@ struct RootView: View {
     @EnvironmentObject private var dependencyContainer: DependencyContainer
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding: Bool = false
     @State private var pendingAction: PostOnboardingAction?
+    @State private var collectionCreateTrigger = false
+    @State private var pageCreateTrigger = false
 
     enum PostOnboardingAction { case createFirst, importSamples }
 
@@ -32,9 +34,16 @@ struct RootView: View {
         .animation(.easeInOut(duration: 0.45), value: hasCompletedOnboarding)
     }
 
+    private var shouldShowFAB: Bool {
+        if router.path.isEmpty { return true }
+        if case .pageList = router.path.last { return true }
+        return false
+    }
+
     private var mainNavigation: some View {
         NavigationStack(path: $router.path) {
             CollectionListScreen(
+                showCreateTrigger: $collectionCreateTrigger,
                 repository: dependencyContainer.collectionRepository,
                 pageRepository: dependencyContainer.pageRepository,
                 nodeRepository: dependencyContainer.nodeRepository,
@@ -45,6 +54,7 @@ struct RootView: View {
                 switch route {
                 case .pageList(let collectionID, let collectionTitle):
                     PageListScreen(
+                        showCreateTrigger: $pageCreateTrigger,
                         collectionID: collectionID,
                         collectionTitle: collectionTitle,
                         pageRepository: dependencyContainer.pageRepository,
@@ -61,6 +71,36 @@ struct RootView: View {
                 }
             }
         }
+        .overlay(alignment: .bottomTrailing) {
+            if shouldShowFAB {
+                fab
+                    .transition(.opacity.combined(with: .scale(scale: 0.8, anchor: .bottomTrailing)))
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: shouldShowFAB)
+        .ignoresSafeArea(.keyboard, edges: .bottom)
         .environmentObject(router)
+    }
+
+    private var fab: some View {
+        Button {
+            if router.path.isEmpty {
+                collectionCreateTrigger = true
+            } else if case .pageList = router.path.last {
+                pageCreateTrigger = true
+            }
+        } label: {
+            Image(systemName: "plus")
+                .font(.title.weight(.semibold))
+                .frame(width: 50, height: 50)
+                .foregroundStyle(Color.black)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.glassProminent)
+        .tint(ColorTokens.accent)
+        .buttonBorderShape(.circle)
+        .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
+        .padding(.trailing, SpacingTokens.md)
+        .padding(.bottom, SpacingTokens.lg)
     }
 }

--- a/Notte/Docs/MVP/Notte M6代码参考文档.md
+++ b/Notte/Docs/MVP/Notte M6代码参考文档.md
@@ -38,7 +38,7 @@ feature/onboarding-settings
 
 ## M6-01 OnboardingView 屏 1：产品理念与层级示意
 
-**文件：** `Features/Onboarding/Views/OnboardingView.swift` / `Features/Onboarding/Components/OnboardingHierarchyIllustration.swift` / `Features/Onboarding/ViewModels/OnboardingViewModel.swift`
+**文件：** `Features/Onboarding/Views/OnboardingScreenOne.swift` / `Features/Onboarding/Components/OnboardingHierarchyIllustration.swift` / `Features/Onboarding/ViewModels/OnboardingViewModel.swift`
 
 ```swift
 // Features/Onboarding/ViewModels/OnboardingViewModel.swift
@@ -100,7 +100,9 @@ struct OnboardingHierarchyIllustration: View {
 ```
 
 ```swift
-// Features/Onboarding/Views/OnboardingView.swift（屏 1 部分，完整文件在 M6-03 给出）
+// Features/Onboarding/Views/OnboardingScreenOne.swift
+import SwiftUI
+
 struct OnboardingScreenOne: View {
     var body: some View {
         VStack(spacing: SpacingTokens.lg) {

--- a/Notte/Features/Collections/ViewModels/CollectionListViewModel.swift
+++ b/Notte/Features/Collections/ViewModels/CollectionListViewModel.swift
@@ -112,4 +112,15 @@ class CollectionListViewModel: ObservableObject {
             self.error = error as? AppError
         }
     }
+    
+    func importSampleData(using factory: ExampleDataFactory) async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            try await factory.importAll()
+            await loadCollections()
+        } catch {
+            self.error = AppError.unknown(error.localizedDescription)
+        }
+    }
 }

--- a/Notte/Features/Collections/ViewModels/CollectionListViewModel.swift
+++ b/Notte/Features/Collections/ViewModels/CollectionListViewModel.swift
@@ -120,7 +120,7 @@ class CollectionListViewModel: ObservableObject {
             try await factory.importAll()
             await loadCollections()
         } catch {
-            self.error = AppError.unknown(error.localizedDescription)
+            self.error = AppError.unknown(error)
         }
     }
 }

--- a/Notte/Features/Collections/ViewModels/CollectionListViewModel.swift
+++ b/Notte/Features/Collections/ViewModels/CollectionListViewModel.swift
@@ -100,6 +100,10 @@ class CollectionListViewModel: ObservableObject {
         }
     }
 
+    func handlePendingCreateFirst() {
+        isShowingCreateSheet = true
+    }
+
     func reorderCollection(moving id: UUID, after targetID: UUID?) async {
         do {
             try await reorderUseCase.execute(moving: id, after: targetID)

--- a/Notte/Features/Collections/Views/CollectionListScreen.swift
+++ b/Notte/Features/Collections/Views/CollectionListScreen.swift
@@ -14,10 +14,15 @@ struct CollectionListScreen: View {
     @State private var editMode: EditMode = .inactive
     @State private var collectionToDelete: Collection?
 
+    let pendingAction: RootView.PostOnboardingAction?
+    let onActionConsumed: () -> Void
+
     init(
         repository: CollectionRepositoryProtocol,
         pageRepository: PageRepositoryProtocol,
-        nodeRepository: NodeRepositoryProtocol
+        nodeRepository: NodeRepositoryProtocol,
+        pendingAction: RootView.PostOnboardingAction? = nil,
+        onActionConsumed: @escaping () -> Void = {}
     ) {
         _viewModel = StateObject(
             wrappedValue: CollectionListViewModel(
@@ -26,6 +31,8 @@ struct CollectionListScreen: View {
                 nodeRepository: nodeRepository
             )
         )
+        self.pendingAction = pendingAction
+        self.onActionConsumed = onActionConsumed
     }
 
     var body: some View {
@@ -97,6 +104,10 @@ struct CollectionListScreen: View {
             }
             .task {
                 await viewModel.loadCollections()
+                if pendingAction == .createFirst {
+                    viewModel.handlePendingCreateFirst()
+                    onActionConsumed()
+                }
             }
         }
     }

--- a/Notte/Features/Collections/Views/CollectionListScreen.swift
+++ b/Notte/Features/Collections/Views/CollectionListScreen.swift
@@ -112,6 +112,7 @@ struct CollectionListScreen: View {
                 onActionConsumed()
             }
         }
+        .ignoresSafeArea(.keyboard, edges: .bottom)
     }
 
     private var contentView: some View {

--- a/Notte/Features/Collections/Views/CollectionListScreen.swift
+++ b/Notte/Features/Collections/Views/CollectionListScreen.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import SwiftData
 
 struct CollectionListScreen: View {
+    @Binding var showCreateTrigger: Bool
     @StateObject private var viewModel: CollectionListViewModel
     @EnvironmentObject private var router: AppRouter
     @EnvironmentObject private var dependencyContainer: DependencyContainer
@@ -20,12 +21,14 @@ struct CollectionListScreen: View {
     let onActionConsumed: () -> Void
 
     init(
+        showCreateTrigger: Binding<Bool> = .constant(false),
         repository: CollectionRepositoryProtocol,
         pageRepository: PageRepositoryProtocol,
         nodeRepository: NodeRepositoryProtocol,
         pendingAction: RootView.PostOnboardingAction? = nil,
         onActionConsumed: @escaping () -> Void = {}
     ) {
+        self._showCreateTrigger = showCreateTrigger
         _viewModel = StateObject(
             wrappedValue: CollectionListViewModel(
                 repository: repository,
@@ -40,9 +43,6 @@ struct CollectionListScreen: View {
     var body: some View {
         NavigationStack {
             contentView
-                .overlay(alignment: .bottomTrailing) {
-                    addButton
-                }
                 .navigationTitle("Notte")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
@@ -111,6 +111,12 @@ struct CollectionListScreen: View {
                 }
                 onActionConsumed()
             }
+            .onChange(of: showCreateTrigger) { _, triggered in
+                if triggered {
+                    viewModel.isShowingCreateSheet = true
+                    showCreateTrigger = false
+                }
+            }
         }
         .ignoresSafeArea(.keyboard, edges: .bottom)
     }
@@ -128,24 +134,6 @@ struct CollectionListScreen: View {
                 collectionList
             }
         }
-    }
-
-    private var addButton: some View {
-        Button {
-            viewModel.isShowingCreateSheet = true
-        } label: {
-            Image(systemName: "plus")
-                .font(.title.weight(.semibold))
-                .frame(width: 50, height: 50)
-                .foregroundStyle(Color.black)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.glassProminent)
-        .tint(ColorTokens.accent)
-        .buttonBorderShape(.circle)
-        .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
-        .padding(.trailing, SpacingTokens.md)
-        .padding(.bottom, SpacingTokens.lg)
     }
 
     private var collectionList: some View {

--- a/Notte/Features/Collections/Views/CollectionListScreen.swift
+++ b/Notte/Features/Collections/Views/CollectionListScreen.swift
@@ -104,10 +104,15 @@ struct CollectionListScreen: View {
             }
             .task {
                 await viewModel.loadCollections()
-                if pendingAction == .createFirst {
+                switch pendingAction {
+                case .createFirst:
                     viewModel.handlePendingCreateFirst()
-                    onActionConsumed()
+                case .importSamples:
+                    await viewModel.importSampleData(using: dependencyContainer.makeExampleDataFactory())
+                case nil:
+                    break
                 }
+                onActionConsumed()
             }
         }
     }

--- a/Notte/Features/Collections/Views/CollectionListScreen.swift
+++ b/Notte/Features/Collections/Views/CollectionListScreen.swift
@@ -134,13 +134,15 @@ struct CollectionListScreen: View {
             viewModel.isShowingCreateSheet = true
         } label: {
             Image(systemName: "plus")
-                .font(.title2.weight(.semibold))
-                .foregroundStyle(ColorTokens.backgroundPrimary)
+                .font(.title.weight(.semibold))
                 .frame(width: 56, height: 56)
-                .background(ColorTokens.accent)
-                .clipShape(Circle())
-                .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
+                .foregroundStyle(Color.black)
+                .contentShape(Rectangle())
         }
+        .buttonStyle(.glassProminent)
+        .tint(ColorTokens.accent)
+        .buttonBorderShape(.circle)
+        .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
         .padding(.trailing, SpacingTokens.md)
         .padding(.bottom, SpacingTokens.lg)
     }

--- a/Notte/Features/Collections/Views/CollectionListScreen.swift
+++ b/Notte/Features/Collections/Views/CollectionListScreen.swift
@@ -11,6 +11,7 @@ import SwiftData
 struct CollectionListScreen: View {
     @StateObject private var viewModel: CollectionListViewModel
     @EnvironmentObject private var router: AppRouter
+    @EnvironmentObject private var dependencyContainer: DependencyContainer
     @State private var editMode: EditMode = .inactive
     @State private var collectionToDelete: Collection?
 
@@ -224,6 +225,7 @@ struct CollectionListScreen: View {
     let repo = try! CollectionRepository(context: context)
     let pageRepo = PageRepository(context: context)
     let nodeRepo = NodeRepository(context: context)
+    let dependencyContainer = DependencyContainer(modelContainer: container)
 
     CollectionListScreen(
         repository: repo,
@@ -236,4 +238,5 @@ struct CollectionListScreen: View {
         try! await createUsecase.execute(title: "实例2")
     }
     .environmentObject(AppRouter())
+    .environmentObject(dependencyContainer)
 }

--- a/Notte/Features/Collections/Views/CollectionListScreen.swift
+++ b/Notte/Features/Collections/Views/CollectionListScreen.swift
@@ -14,6 +14,7 @@ struct CollectionListScreen: View {
     @EnvironmentObject private var dependencyContainer: DependencyContainer
     @State private var editMode: EditMode = .inactive
     @State private var collectionToDelete: Collection?
+    @State private var isShowingSettings = false
 
     let pendingAction: RootView.PostOnboardingAction?
     let onActionConsumed: () -> Void
@@ -38,26 +39,18 @@ struct CollectionListScreen: View {
 
     var body: some View {
         NavigationStack {
-            Group {
-                if viewModel.isLoading {
-                    ProgressView()
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if viewModel.collections.isEmpty {
-                    CollectionEmptyState {
-                        viewModel.isShowingCreateSheet = true
-                    }
-                } else {
-                    collectionList
+            contentView
+                .overlay(alignment: .bottomTrailing) {
+                    addButton
                 }
-            }
-            .navigationTitle("Notte")
+                .navigationTitle("Notte")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
-                        viewModel.isShowingCreateSheet = true
+                        isShowingSettings = true
                     } label: {
-                        Image(systemName: "plus")
+                        Image(systemName: "gearshape")
                             .foregroundStyle(ColorTokens.accent)
                     }
                 }
@@ -70,6 +63,9 @@ struct CollectionListScreen: View {
             .environment(\.editMode, $editMode)
             .sheet(isPresented: $viewModel.isShowingCreateSheet) {
                 CollectionCreateSheet(viewModel: viewModel)
+            }
+            .sheet(isPresented: $isShowingSettings) {
+                SettingsView()
             }
             .sheet(
                 isPresented: Binding(
@@ -116,6 +112,37 @@ struct CollectionListScreen: View {
                 onActionConsumed()
             }
         }
+    }
+
+    private var contentView: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if viewModel.collections.isEmpty {
+                CollectionEmptyState {
+                    viewModel.isShowingCreateSheet = true
+                }
+            } else {
+                collectionList
+            }
+        }
+    }
+
+    private var addButton: some View {
+        Button {
+            viewModel.isShowingCreateSheet = true
+        } label: {
+            Image(systemName: "plus")
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(ColorTokens.backgroundPrimary)
+                .frame(width: 56, height: 56)
+                .background(ColorTokens.accent)
+                .clipShape(Circle())
+                .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
+        }
+        .padding(.trailing, SpacingTokens.md)
+        .padding(.bottom, SpacingTokens.lg)
     }
 
     private var collectionList: some View {

--- a/Notte/Features/Collections/Views/CollectionListScreen.swift
+++ b/Notte/Features/Collections/Views/CollectionListScreen.swift
@@ -135,7 +135,7 @@ struct CollectionListScreen: View {
         } label: {
             Image(systemName: "plus")
                 .font(.title.weight(.semibold))
-                .frame(width: 56, height: 56)
+                .frame(width: 50, height: 50)
                 .foregroundStyle(Color.black)
                 .contentShape(Rectangle())
         }

--- a/Notte/Features/NodeEditor/Components/NodeRowView.swift
+++ b/Notte/Features/NodeEditor/Components/NodeRowView.swift
@@ -68,6 +68,7 @@ struct NodeRowView: View {
             }
         }
         .padding(.vertical, 6)
+        .frame(minHeight: 44)
         .background(
             isFocused
             ? ColorTokens.backgroundSecondary

--- a/Notte/Features/NodeEditor/Views/PageEditorView.swift
+++ b/Notte/Features/NodeEditor/Views/PageEditorView.swift
@@ -61,6 +61,7 @@ struct PageEditorView: View {
                             )
                             .id(node.id)
                             .transition(.nodeExpand)
+                            .zIndex(Double(100 - node.depth))
                         }
 
                         ColorTokens.backgroundPrimary

--- a/Notte/Features/NodeEditor/Views/PageEditorView.swift
+++ b/Notte/Features/NodeEditor/Views/PageEditorView.swift
@@ -131,7 +131,7 @@ struct PageEditorView: View {
                         viewModel.saveChanges()
                     } label: {
                         Image(systemName: "checkmark")
-                            .foregroundStyle(ColorTokens.textPrimary)
+                            .foregroundStyle(Color.black)
                     }
                     .buttonStyle(.borderedProminent)
                     .tint(ColorTokens.accent)

--- a/Notte/Features/NodeEditor/Views/PageEditorView.swift
+++ b/Notte/Features/NodeEditor/Views/PageEditorView.swift
@@ -120,7 +120,7 @@ struct PageEditorView: View {
                     }
                 } label: {
                     Image(systemName: "plus")
-                        .foregroundStyle(ColorTokens.accent)
+                        .foregroundStyle(ColorTokens.textPrimary)
                 } primaryAction: {
                     handleSmartAdd()
                 }

--- a/Notte/Features/Onboarding/Components/OnboardingHierarchyIllustration.swift
+++ b/Notte/Features/Onboarding/Components/OnboardingHierarchyIllustration.swift
@@ -1,0 +1,44 @@
+//
+//  OnboardingHierarchyIllustration.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/12.
+//
+
+import SwiftUI
+
+/// 静态层级示意图：Collection → Page → Node → Block。
+/// 用 SwiftUI 原生组件绘制，不依赖外部素材，深浅色自动适配。
+struct OnboardingHierarchyIllustration: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: SpacingTokens.sm) {
+            tier(icon: "tray.full", title: "Collection", indent: 0)
+            tier(icon: "doc.text", title: "Page", indent: 1)
+            tier(icon: "list.bullet.indent", title: "Node", indent: 2)
+            tier(icon: "text.alignleft", title: "Block", indent: 3)
+        }
+        .padding(SpacingTokens.lg)
+        .background(ColorTokens.backgroundSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    private func tier(icon: String, title: String, indent: Int) -> some View {
+        HStack(spacing: SpacingTokens.sm) {
+            ForEach(0..<indent, id: \.self) { _ in
+                Rectangle()
+                    .fill(ColorTokens.separator.opacity(0.4))
+                    .frame(width: 1, height: 20)
+                    .padding(.horizontal, SpacingTokens.xs)
+            }
+            Image(systemName: icon)
+                .foregroundStyle(ColorTokens.accent)
+            Text(title)
+                .font(TypographyTokens.body)
+                .foregroundStyle(ColorTokens.textPrimary)
+        }
+    }
+}
+
+#Preview {
+    OnboardingHierarchyIllustration()
+}

--- a/Notte/Features/Onboarding/Services/ExampleDataFactory.swift
+++ b/Notte/Features/Onboarding/Services/ExampleDataFactory.swift
@@ -1,0 +1,150 @@
+//
+//  ExampleDataFactory.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/13.
+//
+
+import Foundation
+
+/// JSON Schema：
+/// {
+///   "title": "Collection 标题",
+///   "iconName": "tray.full",
+///   "colorToken": null,
+///   "pages": [
+///     {
+///       "title": "Page 标题",
+///       "nodes": [
+///         {
+///           "title": "Node 标题",
+///           "depth": 0,
+///           "children": [ /* 递归 Node */ ],
+///           "blocks": [
+///             { "type": "text", "content": "Block 内容" }
+///           ]
+///         }
+///       ]
+///     }
+///   ]
+/// }
+struct ExampleDataFactory {
+    let collectionRepository: CollectionRepositoryProtocol
+    let pageRepository: PageRepositoryProtocol
+    let nodeRepository: NodeRepositoryProtocol
+    let blockRepository: BlockRepositoryProtocol
+
+    private let sampleFiles = ["SwiftUILearning", "ProjectPlanning", "ReadingNotes"]
+    private let logger = ConsoleLogger()
+
+    func importAll() async throws {
+        for file in sampleFiles {
+            try await importOne(file: file)
+        }
+    }
+
+    func importOne(file: String) async throws {
+        guard let url = Bundle.main.url(forResource: file, withExtension: "json", subdirectory: "SampleData")
+            ?? Bundle.main.url(forResource: file, withExtension: "json") else {
+            throw RepositoryError.notFound
+        }
+        let data = try Data(contentsOf: url)
+        let dto = try JSONDecoder().decode(SampleCollectionDTO.self, from: data)
+        try await persist(dto: dto)
+        logger.info("示例数据导入完成: \(file)", function: #function)
+    }
+
+    private func persist(dto: SampleCollectionDTO) async throws {
+        let existing = try await collectionRepository.fetchAll()
+        let baseSortIndex = (existing.map(\.sortIndex).max() ?? 0) + 1000
+
+        let collection = Collection(
+            id: UUID(),
+            title: dto.title,
+            iconName: dto.iconName,
+            colorToken: dto.colorToken,
+            createdAt: Date(),
+            updatedAt: Date(),
+            sortIndex: baseSortIndex,
+            isPinned: false
+        )
+        try await collectionRepository.create(collection)
+
+        for (pageIdx, pageDTO) in dto.pages.enumerated() {
+            let page = Page(
+                id: UUID(),
+                collectionID: collection.id,
+                title: pageDTO.title,
+                createdAt: Date(),
+                updatedAt: Date(),
+                sortIndex: Double(pageIdx + 1) * 1000,
+                isArchived: false
+            )
+            try await pageRepository.create(page)
+
+            try await persistNodes(pageDTO.nodes, pageID: page.id, parentNodeID: nil)
+        }
+    }
+
+    private func persistNodes(
+        _ dtos: [SampleNodeDTO],
+        pageID: UUID,
+        parentNodeID: UUID?
+    ) async throws {
+        for (idx, dto) in dtos.enumerated() {
+            let node = Node(
+                id: UUID(),
+                pageID: pageID,
+                parentNodeID: parentNodeID,
+                title: dto.title,
+                depth: dto.depth,
+                sortIndex: Double(idx + 1) * 1000,
+                isCollapsed: false,
+                createdAt: Date(),
+                updatedAt: Date()
+            )
+            try await nodeRepository.create(node)
+
+            for (blockIdx, blockDTO) in (dto.blocks ?? []).enumerated() {
+                let block = Block(
+                    id: UUID(),
+                    nodeID: node.id,
+                    type: BlockType(rawValue: blockDTO.type) ?? .text,
+                    content: blockDTO.content,
+                    sortIndex: Double(blockIdx + 1) * 1000,
+                    createdAt: Date(),
+                    updatedAt: Date()
+                )
+                try await blockRepository.create(block)
+            }
+
+            try await persistNodes(dto.children ?? [], pageID: pageID, parentNodeID: node.id)
+        }
+    }
+}
+
+// MARK: - DTO
+
+private struct SampleCollectionDTO: Decodable {
+    let title: String
+    let iconName: String?
+    let colorToken: String?
+    let pages: [SamplePageDTO]
+}
+
+private struct SamplePageDTO: Decodable {
+    let title: String
+    let nodes: [SampleNodeDTO]
+}
+
+private struct SampleNodeDTO: Decodable {
+    let title: String
+    let depth: Int
+    let children: [SampleNodeDTO]?
+    let blocks: [SampleBlockDTO]?
+}
+
+private struct SampleBlockDTO: Decodable {
+    let type: String
+    let content: String
+}

--- a/Notte/Features/Onboarding/Services/ExampleDataFactory.swift
+++ b/Notte/Features/Onboarding/Services/ExampleDataFactory.swift
@@ -105,17 +105,31 @@ struct ExampleDataFactory {
             )
             try await nodeRepository.create(node)
 
-            for (blockIdx, blockDTO) in (dto.blocks ?? []).enumerated() {
-                let block = Block(
+            let blockDTOs = dto.blocks ?? []
+            if blockDTOs.isEmpty {
+                let emptyBlock = Block(
                     id: UUID(),
                     nodeID: node.id,
-                    type: BlockType(rawValue: blockDTO.type) ?? .text,
-                    content: blockDTO.content,
-                    sortIndex: Double(blockIdx + 1) * 1000,
+                    type: .text,
+                    content: "",
+                    sortIndex: 1000,
                     createdAt: Date(),
                     updatedAt: Date()
                 )
-                try await blockRepository.create(block)
+                try await blockRepository.create(emptyBlock)
+            } else {
+                for (blockIdx, blockDTO) in blockDTOs.enumerated() {
+                    let block = Block(
+                        id: UUID(),
+                        nodeID: node.id,
+                        type: BlockType(rawValue: blockDTO.type) ?? .text,
+                        content: blockDTO.content,
+                        sortIndex: Double(blockIdx + 1) * 1000,
+                        createdAt: Date(),
+                        updatedAt: Date()
+                    )
+                    try await blockRepository.create(block)
+                }
             }
 
             try await persistNodes(dto.children ?? [], pageID: pageID, parentNodeID: node.id)

--- a/Notte/Features/Onboarding/ViewModels/OnboardingViewModel.swift
+++ b/Notte/Features/Onboarding/ViewModels/OnboardingViewModel.swift
@@ -1,0 +1,25 @@
+//
+//  OnboardingViewModel.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/12.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+class OnboardingViewModel: ObservableObject {
+    @Published var currentPage: Int = 0
+    let totalPages: Int = 3
+
+    func next() {
+        guard currentPage < totalPages - 1 else { return }
+        currentPage += 1
+    }
+
+    func previous() {
+        guard currentPage > 0 else { return }
+        currentPage -= 1
+    }
+}

--- a/Notte/Features/Onboarding/Views/OnboardingScreenOne.swift
+++ b/Notte/Features/Onboarding/Views/OnboardingScreenOne.swift
@@ -1,0 +1,27 @@
+//
+//  OnboardingScreenOne.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/12.
+//
+
+import SwiftUI
+
+struct OnboardingScreenOne: View {
+    var body: some View {
+        VStack(spacing: SpacingTokens.lg) {
+            Spacer()
+            Text("结构化地记录一切")
+                .font(TypographyTokens.largeTitle)
+                .foregroundStyle(ColorTokens.textPrimary)
+            Text("Notte 帮助你快速记录，自然形成结构，长期积累知识。")
+                .font(TypographyTokens.body)
+                .foregroundStyle(ColorTokens.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, SpacingTokens.lg)
+            OnboardingHierarchyIllustration()
+            Spacer()
+        }
+        .padding(.horizontal, SpacingTokens.md)
+    }
+}

--- a/Notte/Features/Onboarding/Views/OnboardingScreenOne.swift
+++ b/Notte/Features/Onboarding/Views/OnboardingScreenOne.swift
@@ -25,3 +25,7 @@ struct OnboardingScreenOne: View {
         .padding(.horizontal, SpacingTokens.md)
     }
 }
+
+#Preview {
+    OnboardingScreenOne()
+}

--- a/Notte/Features/Onboarding/Views/OnboardingScreenThree.swift
+++ b/Notte/Features/Onboarding/Views/OnboardingScreenThree.swift
@@ -8,9 +8,6 @@
 import SwiftUI
 
 struct OnboardingScreenThree: View {
-    let onCreateFirstCollection: () -> Void
-    let onImportSampleData: () -> Void
-
     var body: some View {
         VStack(spacing: SpacingTokens.lg) {
             Spacer()
@@ -20,25 +17,6 @@ struct OnboardingScreenThree: View {
             Text("选择一种方式开始")
                 .font(TypographyTokens.body)
                 .foregroundStyle(ColorTokens.textSecondary)
-
-            VStack(spacing: SpacingTokens.sm) {
-                Button(action: onCreateFirstCollection) {
-                    Text("创建我的第一个 Collection")
-                        .font(TypographyTokens.body.bold())
-                        .padding(.horizontal, SpacingTokens.md)
-                        .padding(.vertical, SpacingTokens.xs)
-                }
-                .buttonStyle(.glassProminent)
-                .tint(ColorTokens.accent)
-
-                Button(action: onImportSampleData) {
-                    Text("导入示例数据")
-                        .font(TypographyTokens.body)
-                        .padding(.horizontal, SpacingTokens.md)
-                        .padding(.vertical, SpacingTokens.xs)
-                }
-                .buttonStyle(.glass)
-            }
             Spacer()
         }
         .padding(.horizontal, SpacingTokens.md)
@@ -46,5 +24,5 @@ struct OnboardingScreenThree: View {
 }
 
 #Preview {
-    OnboardingScreenThree(onCreateFirstCollection: {}, onImportSampleData: {})
+    OnboardingScreenThree()
 }

--- a/Notte/Features/Onboarding/Views/OnboardingScreenThree.swift
+++ b/Notte/Features/Onboarding/Views/OnboardingScreenThree.swift
@@ -1,0 +1,50 @@
+//
+//  OnboardingScreenThree.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/12.
+//
+
+import SwiftUI
+
+struct OnboardingScreenThree: View {
+    let onCreateFirstCollection: () -> Void
+    let onImportSampleData: () -> Void
+
+    var body: some View {
+        VStack(spacing: SpacingTokens.lg) {
+            Spacer()
+            Text("准备好了吗？")
+                .font(TypographyTokens.largeTitle)
+                .foregroundStyle(ColorTokens.textPrimary)
+            Text("选择一种方式开始")
+                .font(TypographyTokens.body)
+                .foregroundStyle(ColorTokens.textSecondary)
+
+            VStack(spacing: SpacingTokens.sm) {
+                Button(action: onCreateFirstCollection) {
+                    Text("创建我的第一个 Collection")
+                        .font(TypographyTokens.body.bold())
+                        .padding(.horizontal, SpacingTokens.md)
+                        .padding(.vertical, SpacingTokens.xs)
+                }
+                .buttonStyle(.glassProminent)
+                .tint(ColorTokens.accent)
+
+                Button(action: onImportSampleData) {
+                    Text("导入示例数据")
+                        .font(TypographyTokens.body)
+                        .padding(.horizontal, SpacingTokens.md)
+                        .padding(.vertical, SpacingTokens.xs)
+                }
+                .buttonStyle(.glass)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, SpacingTokens.md)
+    }
+}
+
+#Preview {
+    OnboardingScreenThree(onCreateFirstCollection: {}, onImportSampleData: {})
+}

--- a/Notte/Features/Onboarding/Views/OnboardingScreenTwo.swift
+++ b/Notte/Features/Onboarding/Views/OnboardingScreenTwo.swift
@@ -1,0 +1,63 @@
+//
+//  OnboardingScreenTwo.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/12.
+//
+
+import SwiftUI
+
+struct OnboardingScreenTwo: View {
+    var body: some View {
+        VStack(spacing: SpacingTokens.lg) {
+            Spacer()
+            Text("三个对象，一套系统")
+                .font(TypographyTokens.largeTitle)
+                .foregroundStyle(ColorTokens.textPrimary)
+
+            VStack(alignment: .leading, spacing: SpacingTokens.md) {
+                conceptRow(
+                    icon: "tray.full",
+                    title: "Collection",
+                    subtitle: "专题空间，按主题组织所有内容"
+                )
+                conceptRow(
+                    icon: "doc.text",
+                    title: "Page",
+                    subtitle: "一篇完整的笔记或文档"
+                )
+                conceptRow(
+                    icon: "list.bullet.indent",
+                    title: "Node",
+                    subtitle: "可自由移动、重组的内容模块"
+                )
+            }
+            .padding(SpacingTokens.lg)
+            .background(ColorTokens.backgroundSecondary)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            Spacer()
+        }
+        .padding(.horizontal, SpacingTokens.md)
+    }
+
+    private func conceptRow(icon: String, title: String, subtitle: String) -> some View {
+        HStack(alignment: .top, spacing: SpacingTokens.md) {
+            Image(systemName: icon)
+                .font(.system(size: 22, weight: .medium))
+                .foregroundStyle(ColorTokens.accent)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: SpacingTokens.xs) {
+                Text(title)
+                    .font(TypographyTokens.title)
+                    .foregroundStyle(ColorTokens.textPrimary)
+                Text(subtitle)
+                    .font(TypographyTokens.body)
+                    .foregroundStyle(ColorTokens.textSecondary)
+            }
+        }
+    }
+}
+
+#Preview {
+    OnboardingScreenTwo()
+}

--- a/Notte/Features/Onboarding/Views/OnboardingView.swift
+++ b/Notte/Features/Onboarding/Views/OnboardingView.swift
@@ -1,0 +1,58 @@
+//
+//  OnboardingView.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/12.
+//
+
+import SwiftUI
+
+struct OnboardingView: View {
+    @StateObject private var viewModel = OnboardingViewModel()
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding: Bool = false
+
+    let onCreateFirstCollection: () -> Void
+    let onImportSampleData: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Spacer()
+                Button("跳过") {
+                    hasCompletedOnboarding = true
+                }
+                .font(TypographyTokens.body)
+                .foregroundStyle(ColorTokens.textSecondary)
+                .padding(SpacingTokens.md)
+            }
+
+            TabView(selection: $viewModel.currentPage) {
+                OnboardingScreenOne()
+                    .tag(0)
+                OnboardingScreenTwo()
+                    .tag(1)
+                OnboardingScreenThree(
+                    onCreateFirstCollection: {
+                        hasCompletedOnboarding = true
+                        onCreateFirstCollection()
+                    },
+                    onImportSampleData: {
+                        hasCompletedOnboarding = true
+                        onImportSampleData()
+                    }
+                )
+                .tag(2)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .indexViewStyle(.page(backgroundDisplayMode: .always))
+        }
+        .background(ColorTokens.backgroundPrimary)
+    }
+}
+
+#Preview {
+    OnboardingView(
+        onCreateFirstCollection: {},
+        onImportSampleData: {}
+    )
+}

--- a/Notte/Features/Onboarding/Views/OnboardingView.swift
+++ b/Notte/Features/Onboarding/Views/OnboardingView.swift
@@ -31,22 +31,59 @@ struct OnboardingView: View {
                     .tag(0)
                 OnboardingScreenTwo()
                     .tag(1)
-                OnboardingScreenThree(
-                    onCreateFirstCollection: {
-                        hasCompletedOnboarding = true
-                        onCreateFirstCollection()
-                    },
-                    onImportSampleData: {
-                        hasCompletedOnboarding = true
-                        onImportSampleData()
-                    }
-                )
-                .tag(2)
+                OnboardingScreenThree()
+                    .tag(2)
             }
             .tabViewStyle(.page(indexDisplayMode: .always))
             .indexViewStyle(.page(backgroundDisplayMode: .always))
+
+            ctaArea
+                .padding(.horizontal, SpacingTokens.md)
+                .padding(.bottom, SpacingTokens.lg)
         }
         .background(ColorTokens.backgroundPrimary)
+    }
+
+    @ViewBuilder
+    private var ctaArea: some View {
+        if viewModel.currentPage < 2 {
+            Button(action: viewModel.next) {
+                Text("下一步")
+                    .font(TypographyTokens.body.bold())
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, SpacingTokens.sm)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(ColorTokens.accent)
+            .padding(.top, SpacingTokens.sm)
+        } else {
+            VStack(spacing: SpacingTokens.sm) {
+                Button(action: {
+                    hasCompletedOnboarding = true
+                    onCreateFirstCollection()
+                }) {
+                    Text("创建我的第一个 Collection")
+                        .font(TypographyTokens.body.bold())
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, SpacingTokens.sm)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(ColorTokens.accent)
+
+                Button(action: {
+                    hasCompletedOnboarding = true
+                    onImportSampleData()
+                }) {
+                    Text("导入示例数据")
+                        .font(TypographyTokens.body)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, SpacingTokens.sm)
+                }
+                .buttonStyle(.bordered)
+                .tint(ColorTokens.accent)
+            }
+            .padding(.top, SpacingTokens.sm)
+        }
     }
 }
 

--- a/Notte/Features/Onboarding/Views/OnboardingView.swift
+++ b/Notte/Features/Onboarding/Views/OnboardingView.swift
@@ -18,20 +18,29 @@ struct OnboardingView: View {
         VStack(spacing: 0) {
             HStack {
                 Spacer()
-                Button("跳过") {
+                Button {
                     hasCompletedOnboarding = true
+                } label: {
+                    Text("跳过")
+                        .padding(.vertical, SpacingTokens.xs)
+                        .padding(.horizontal, SpacingTokens.xs)
                 }
                 .font(TypographyTokens.body)
-                .foregroundStyle(ColorTokens.textSecondary)
-                .padding(SpacingTokens.md)
+                .buttonStyle(.glass)
+                .padding(.vertical, SpacingTokens.sm)
+                .padding(.horizontal, SpacingTokens.md)
             }
+            .padding(.trailing, SpacingTokens.sm)
 
             TabView(selection: $viewModel.currentPage) {
                 OnboardingScreenOne()
+                    .padding(.bottom, SpacingTokens.xl * 3)
                     .tag(0)
                 OnboardingScreenTwo()
+                    .padding(.bottom, SpacingTokens.xl * 3)
                     .tag(1)
                 OnboardingScreenThree()
+                    .padding(.bottom, SpacingTokens.xl * 3)
                     .tag(2)
             }
             .tabViewStyle(.page(indexDisplayMode: .always))
@@ -53,7 +62,7 @@ struct OnboardingView: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, SpacingTokens.sm)
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(.glassProminent)
             .tint(ColorTokens.accent)
             .padding(.top, SpacingTokens.sm)
         } else {
@@ -67,7 +76,7 @@ struct OnboardingView: View {
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, SpacingTokens.sm)
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.glassProminent)
                 .tint(ColorTokens.accent)
 
                 Button(action: {
@@ -79,8 +88,7 @@ struct OnboardingView: View {
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, SpacingTokens.sm)
                 }
-                .buttonStyle(.bordered)
-                .tint(ColorTokens.accent)
+                .buttonStyle(.glass)
             }
             .padding(.top, SpacingTokens.sm)
         }

--- a/Notte/Features/Onboarding/Views/OnboardingView.swift
+++ b/Notte/Features/Onboarding/Views/OnboardingView.swift
@@ -19,7 +19,9 @@ struct OnboardingView: View {
             HStack {
                 Spacer()
                 Button {
-                    hasCompletedOnboarding = true
+                    withAnimation(.easeInOut(duration: 0.45)) {
+                        hasCompletedOnboarding = true
+                    }
                 } label: {
                     Text("跳过")
                         .padding(.vertical, SpacingTokens.xs)
@@ -47,6 +49,7 @@ struct OnboardingView: View {
             .indexViewStyle(.page(backgroundDisplayMode: .always))
 
             ctaArea
+                .animation(.spring(response: 0.45, dampingFraction: 0.85), value: viewModel.currentPage < 2)
                 .padding(.horizontal, SpacingTokens.md)
                 .padding(.bottom, SpacingTokens.lg)
         }
@@ -56,7 +59,11 @@ struct OnboardingView: View {
     @ViewBuilder
     private var ctaArea: some View {
         if viewModel.currentPage < 2 {
-            Button(action: viewModel.next) {
+            Button(action: {
+                withAnimation(.spring(response: 0.5, dampingFraction: 0.88)) {
+                    viewModel.next()
+                }
+            }) {
                 Text("下一步")
                     .font(TypographyTokens.body.bold())
                     .frame(maxWidth: .infinity)
@@ -65,10 +72,13 @@ struct OnboardingView: View {
             .buttonStyle(.glassProminent)
             .tint(ColorTokens.accent)
             .padding(.top, SpacingTokens.sm)
+            .transition(.opacity.combined(with: .move(edge: .bottom)))
         } else {
             VStack(spacing: SpacingTokens.sm) {
                 Button(action: {
-                    hasCompletedOnboarding = true
+                    withAnimation(.easeInOut(duration: 0.45)) {
+                        hasCompletedOnboarding = true
+                    }
                     onCreateFirstCollection()
                 }) {
                     Text("创建我的第一个 Collection")
@@ -80,7 +90,9 @@ struct OnboardingView: View {
                 .tint(ColorTokens.accent)
 
                 Button(action: {
-                    hasCompletedOnboarding = true
+                    withAnimation(.easeInOut(duration: 0.45)) {
+                        hasCompletedOnboarding = true
+                    }
                     onImportSampleData()
                 }) {
                     Text("导入示例数据")
@@ -91,6 +103,7 @@ struct OnboardingView: View {
                 .buttonStyle(.glass)
             }
             .padding(.top, SpacingTokens.sm)
+            .transition(.opacity.combined(with: .move(edge: .bottom)))
         }
     }
 }

--- a/Notte/Features/Pages/Views/PageListScreen.swift
+++ b/Notte/Features/Pages/Views/PageListScreen.swift
@@ -9,18 +9,21 @@ import SwiftUI
 import SwiftData
 
 struct PageListScreen: View {
+    @Binding var showCreateTrigger: Bool
     @StateObject private var viewModel: PageListViewModel
     @EnvironmentObject private var router: AppRouter
     @State private var editMode: EditMode = .inactive
     @State private var pageToDelete: Page?
 
     init(
+        showCreateTrigger: Binding<Bool> = .constant(false),
         collectionID: UUID,
         collectionTitle: String,
         pageRepository: PageRepositoryProtocol,
         nodeRepository: NodeRepositoryProtocol,
         blockRepository: BlockRepositoryProtocol
     ) {
+        self._showCreateTrigger = showCreateTrigger
         _viewModel = StateObject(
             wrappedValue: PageListViewModel(
                 collectionID: collectionID,
@@ -34,9 +37,6 @@ struct PageListScreen: View {
     
     var body: some View {
         contentView
-            .overlay(alignment: .bottomTrailing) {
-                addButton
-            }
             .ignoresSafeArea(.keyboard, edges: .bottom)
             .navigationTitle(viewModel.collectionTitle)
             .navigationBarTitleDisplayMode(.large)
@@ -57,6 +57,12 @@ struct PageListScreen: View {
             .modifier(PageErrorAlertModifier(viewModel: viewModel))
             .task {
                 await viewModel.loadPages()
+            }
+            .onChange(of: showCreateTrigger) { _, triggered in
+                if triggered {
+                    viewModel.isShowingCreateSheet = true
+                    showCreateTrigger = false
+                }
             }
     }
 
@@ -81,24 +87,6 @@ struct PageListScreen: View {
                 .tint(ColorTokens.accent)
                 .disabled(viewModel.pages.isEmpty)
         }
-    }
-
-    private var addButton: some View {
-        Button {
-            viewModel.isShowingCreateSheet = true
-        } label: {
-            Image(systemName: "plus")
-                .font(.title.weight(.semibold))
-                .frame(width: 50, height: 50)
-                .foregroundStyle(Color.black)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.glassProminent)
-        .tint(ColorTokens.accent)
-        .buttonBorderShape(.circle)
-        .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
-        .padding(.trailing, SpacingTokens.md)
-        .padding(.bottom, SpacingTokens.lg)
     }
 
     private var pageList: some View {

--- a/Notte/Features/Pages/Views/PageListScreen.swift
+++ b/Notte/Features/Pages/Views/PageListScreen.swift
@@ -88,7 +88,7 @@ struct PageListScreen: View {
         } label: {
             Image(systemName: "plus")
                 .font(.title.weight(.semibold))
-                .frame(width: 56, height: 56)
+                .frame(width: 50, height: 50)
                 .foregroundStyle(Color.black)
                 .contentShape(Rectangle())
         }

--- a/Notte/Features/Pages/Views/PageListScreen.swift
+++ b/Notte/Features/Pages/Views/PageListScreen.swift
@@ -87,13 +87,15 @@ struct PageListScreen: View {
             viewModel.isShowingCreateSheet = true
         } label: {
             Image(systemName: "plus")
-                .font(.title2.weight(.semibold))
-                .foregroundStyle(ColorTokens.backgroundPrimary)
+                .font(.title.weight(.semibold))
                 .frame(width: 56, height: 56)
-                .background(ColorTokens.accent)
-                .clipShape(Circle())
-                .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
+                .foregroundStyle(Color.black)
+                .contentShape(Rectangle())
         }
+        .buttonStyle(.glassProminent)
+        .tint(ColorTokens.accent)
+        .buttonBorderShape(.circle)
+        .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
         .padding(.trailing, SpacingTokens.md)
         .padding(.bottom, SpacingTokens.lg)
     }

--- a/Notte/Features/Pages/Views/PageListScreen.swift
+++ b/Notte/Features/Pages/Views/PageListScreen.swift
@@ -34,6 +34,9 @@ struct PageListScreen: View {
     
     var body: some View {
         contentView
+            .overlay(alignment: .bottomTrailing) {
+                addButton
+            }
             .navigationTitle(viewModel.collectionTitle)
             .navigationBarTitleDisplayMode(.large)
             .toolbar { toolbarContent }
@@ -72,19 +75,27 @@ struct PageListScreen: View {
 
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
-        ToolbarItem(placement: .topBarTrailing) {
-            Button {
-                viewModel.isShowingCreateSheet = true
-            } label: {
-                Image(systemName: "plus")
-                    .foregroundStyle(ColorTokens.accent)
-            }
-        }
         ToolbarItem(placement: .topBarLeading) {
             EditButton()
                 .tint(ColorTokens.accent)
                 .disabled(viewModel.pages.isEmpty)
         }
+    }
+
+    private var addButton: some View {
+        Button {
+            viewModel.isShowingCreateSheet = true
+        } label: {
+            Image(systemName: "plus")
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(ColorTokens.backgroundPrimary)
+                .frame(width: 56, height: 56)
+                .background(ColorTokens.accent)
+                .clipShape(Circle())
+                .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
+        }
+        .padding(.trailing, SpacingTokens.md)
+        .padding(.bottom, SpacingTokens.lg)
     }
 
     private var pageList: some View {

--- a/Notte/Features/Pages/Views/PageListScreen.swift
+++ b/Notte/Features/Pages/Views/PageListScreen.swift
@@ -37,6 +37,7 @@ struct PageListScreen: View {
             .overlay(alignment: .bottomTrailing) {
                 addButton
             }
+            .ignoresSafeArea(.keyboard, edges: .bottom)
             .navigationTitle(viewModel.collectionTitle)
             .navigationBarTitleDisplayMode(.large)
             .toolbar { toolbarContent }

--- a/Notte/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/Notte/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  SettingsViewModel.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/14.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+class SettingsViewModel: ObservableObject {
+    @Published var appVersion: String = {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+        return "\(version) (\(build))"
+    }()
+}

--- a/Notte/Features/Settings/Views/SettingsAboutSection.swift
+++ b/Notte/Features/Settings/Views/SettingsAboutSection.swift
@@ -1,0 +1,37 @@
+//
+//  SettingsAboutSection.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/14.
+//
+
+import SwiftUI
+
+struct SettingsAboutSection: View {
+    let version: String
+
+    private let feedbackURL = URL(string: "mailto:feedback@notte.app")!
+    private let privacyURL = URL(string: "https://notte.app/privacy")!
+
+    var body: some View {
+        Section("关于 Notte") {
+            HStack {
+                Text("版本")
+                    .font(TypographyTokens.body)
+                    .foregroundStyle(ColorTokens.textPrimary)
+                Spacer()
+                Text(version)
+                    .font(TypographyTokens.body)
+                    .foregroundStyle(ColorTokens.textSecondary)
+            }
+            Link(destination: feedbackURL) {
+                Label("反馈与建议", systemImage: "envelope")
+                    .foregroundStyle(ColorTokens.textPrimary)
+            }
+            Link(destination: privacyURL) {
+                Label("隐私政策", systemImage: "hand.raised")
+                    .foregroundStyle(ColorTokens.textPrimary)
+            }
+        }
+    }
+}

--- a/Notte/Features/Settings/Views/SettingsAppearanceSection.swift
+++ b/Notte/Features/Settings/Views/SettingsAppearanceSection.swift
@@ -1,0 +1,25 @@
+//
+//  SettingsAppearanceSection.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/14.
+//
+
+import SwiftUI
+
+struct SettingsAppearanceSection: View {
+    var body: some View {
+        Section("外观") {
+            HStack {
+                Image(systemName: "circle.lefthalf.filled")
+                    .foregroundStyle(ColorTokens.textSecondary)
+                Text("跟随系统")
+                    .font(TypographyTokens.body)
+                    .foregroundStyle(ColorTokens.textPrimary)
+            }
+            Text("Notte 会自动适配你在系统设置中选择的浅色或深色模式。")
+                .font(TypographyTokens.caption)
+                .foregroundStyle(ColorTokens.textSecondary)
+        }
+    }
+}

--- a/Notte/Features/Settings/Views/SettingsDebugSection.swift
+++ b/Notte/Features/Settings/Views/SettingsDebugSection.swift
@@ -1,0 +1,53 @@
+//
+//  SettingsDebugSection.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/14.
+//
+
+import SwiftUI
+import SwiftData
+
+#if DEBUG
+struct SettingsDebugSection: View {
+    @Environment(\.modelContext) private var modelContext
+    @EnvironmentObject private var dependencyContainer: DependencyContainer
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding: Bool = false
+    @State private var isImporting: Bool = false
+
+    var body: some View {
+        Section("调试") {
+            Button {
+                isImporting = true
+                Task {
+                    try? await dependencyContainer.makeExampleDataFactory().importAll()
+                    isImporting = false
+                }
+            } label: {
+                Label(isImporting ? "导入中..." : "填充示例数据", systemImage: "tray.and.arrow.down")
+            }
+            .disabled(isImporting)
+
+            Button(role: .destructive) {
+                clearAllData()
+            } label: {
+                Label("清空所有数据", systemImage: "trash")
+            }
+
+            Button {
+                hasCompletedOnboarding = false
+            } label: {
+                Label("重新查看引导", systemImage: "arrow.counterclockwise")
+            }
+        }
+    }
+
+    private func clearAllData() {
+        try? modelContext.delete(model: CollectionModel.self)
+        try? modelContext.delete(model: PageModel.self)
+        try? modelContext.delete(model: NodeModel.self)
+        try? modelContext.delete(model: BlockModel.self)
+        try? modelContext.save()
+    }
+}
+#endif

--- a/Notte/Features/Settings/Views/SettingsSyncSection.swift
+++ b/Notte/Features/Settings/Views/SettingsSyncSection.swift
@@ -1,0 +1,29 @@
+//
+//  SettingsSyncSection.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/14.
+//
+
+import SwiftUI
+
+struct SettingsSyncSection: View {
+    var body: some View {
+        Section("iCloud 同步") {
+            HStack {
+                Image(systemName: "icloud")
+                    .foregroundStyle(ColorTokens.textSecondary)
+                Text("未开启")
+                    .font(TypographyTokens.body)
+                    .foregroundStyle(ColorTokens.textPrimary)
+                Spacer()
+                Text("即将推出")
+                    .font(TypographyTokens.caption)
+                    .foregroundStyle(ColorTokens.textSecondary)
+            }
+            Text("启用后，你的 Collection、Page、Node 将自动同步到你的所有 Apple 设备。")
+                .font(TypographyTokens.caption)
+                .foregroundStyle(ColorTokens.textSecondary)
+        }
+    }
+}

--- a/Notte/Features/Settings/Views/SettingsView.swift
+++ b/Notte/Features/Settings/Views/SettingsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @StateObject private var viewModel = SettingsViewModel()
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         NavigationStack {
@@ -23,6 +24,16 @@ struct SettingsView: View {
             .listStyle(.insetGrouped)
             .navigationTitle("设置")
             .background(ColorTokens.backgroundPrimary)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "checkmark")
+                            .foregroundStyle(ColorTokens.accent)
+                    }
+                }
+            }
         }
     }
 }

--- a/Notte/Features/Settings/Views/SettingsView.swift
+++ b/Notte/Features/Settings/Views/SettingsView.swift
@@ -1,0 +1,28 @@
+//
+//  SettingsView.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/14.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @StateObject private var viewModel = SettingsViewModel()
+
+    var body: some View {
+        NavigationStack {
+            List {
+                SettingsSyncSection()
+                SettingsAppearanceSection()
+                SettingsAboutSection(version: viewModel.appVersion)
+                #if DEBUG
+                SettingsDebugSection()
+                #endif
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("设置")
+            .background(ColorTokens.backgroundPrimary)
+        }
+    }
+}

--- a/Notte/Features/Settings/Views/SettingsView.swift
+++ b/Notte/Features/Settings/Views/SettingsView.swift
@@ -23,20 +23,21 @@ struct SettingsView: View {
             }
             .listStyle(.insetGrouped)
             .navigationTitle("设置")
+            .navigationBarTitleDisplayMode(.inline)
             .background(ColorTokens.backgroundPrimary)
-        }
-        .overlay(alignment: .bottomTrailing) {
-            Button {
-                dismiss()
-            } label: {
-                Image(systemName: "checkmark")
-                    .font(.title2.weight(.semibold))
-                    .foregroundStyle(.black)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "checkmark")
+                            .font(.body.weight(.semibold))
+                            .foregroundStyle(.black)
+                    }
+                    .buttonStyle(.glassProminent)
+                    .tint(ColorTokens.accent)
+                }
             }
-            .buttonStyle(.glass)
-            .padding(.trailing, SpacingTokens.md)
-            .padding(.bottom, SpacingTokens.lg)
         }
-        .ignoresSafeArea(.keyboard, edges: .bottom)
     }
 }

--- a/Notte/Features/Settings/Views/SettingsView.swift
+++ b/Notte/Features/Settings/Views/SettingsView.swift
@@ -24,16 +24,18 @@ struct SettingsView: View {
             .listStyle(.insetGrouped)
             .navigationTitle("设置")
             .background(ColorTokens.backgroundPrimary)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Image(systemName: "checkmark")
-                            .foregroundStyle(ColorTokens.accent)
-                    }
-                }
+        }
+        .overlay(alignment: .bottomTrailing) {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "checkmark")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(.black)
             }
+            .buttonStyle(.glass)
+            .padding(.trailing, SpacingTokens.md)
+            .padding(.bottom, SpacingTokens.lg)
         }
     }
 }

--- a/Notte/Features/Settings/Views/SettingsView.swift
+++ b/Notte/Features/Settings/Views/SettingsView.swift
@@ -37,5 +37,6 @@ struct SettingsView: View {
             .padding(.trailing, SpacingTokens.md)
             .padding(.bottom, SpacingTokens.lg)
         }
+        .ignoresSafeArea(.keyboard, edges: .bottom)
     }
 }

--- a/Notte/Resources/SampleData/ProjectPlanning.json
+++ b/Notte/Resources/SampleData/ProjectPlanning.json
@@ -1,0 +1,42 @@
+{
+  "title": "项目规划",
+  "iconName": "list.clipboard",
+  "colorToken": null,
+  "pages": [
+    {
+      "title": "需求梳理",
+      "nodes": [
+        { "title": "用户故事", "depth": 0, "blocks": [{ "type": "text", "content": "作为 …，我希望 …，以便 …。" }] },
+        { "title": "竞品调研", "depth": 0, "blocks": [{ "type": "text", "content": "列出 3-5 个主要竞品的差异点。" }] },
+        { "title": "MVP 范围", "depth": 0, "blocks": [{ "type": "text", "content": "明确 in-scope / out-of-scope。" }] }
+      ]
+    },
+    {
+      "title": "里程碑",
+      "nodes": [
+        {
+          "title": "Milestone 1",
+          "depth": 0,
+          "children": [
+            { "title": "工程底座", "depth": 1, "blocks": [{ "type": "text", "content": "工程可运行、数据模型就位。" }] },
+            { "title": "首屏可见", "depth": 1, "blocks": [{ "type": "text", "content": "Collection 列表与空状态。" }] }
+          ]
+        },
+        {
+          "title": "Milestone 2",
+          "depth": 0,
+          "children": [
+            { "title": "Editor 核心", "depth": 1, "blocks": [{ "type": "text", "content": "增删改、缩进、折叠全部成立。" }] }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "风险与对策",
+      "nodes": [
+        { "title": "技术风险", "depth": 0, "blocks": [{ "type": "text", "content": "CloudKit 同步在阶段 7 才接入，确保模型字段提前稳定。" }] },
+        { "title": "进度风险", "depth": 0, "blocks": [{ "type": "text", "content": "Editor 阶段如延期，优先砍 UX polish。" }] }
+      ]
+    }
+  ]
+}

--- a/Notte/Resources/SampleData/ReadingNotes.json
+++ b/Notte/Resources/SampleData/ReadingNotes.json
@@ -1,0 +1,30 @@
+{
+  "title": "读书笔记",
+  "iconName": "book",
+  "colorToken": null,
+  "pages": [
+    {
+      "title": "《思考，快与慢》",
+      "nodes": [
+        { "title": "系统 1 与系统 2", "depth": 0, "blocks": [{ "type": "text", "content": "直觉系统快但易错，理性系统慢但准确。" }] },
+        {
+          "title": "认知偏差",
+          "depth": 0,
+          "children": [
+            { "title": "锚定效应", "depth": 1, "blocks": [{ "type": "text", "content": "初始数值会影响后续判断。" }] },
+            { "title": "可得性启发", "depth": 1, "blocks": [{ "type": "text", "content": "越容易回忆的事件被判断为越常见。" }] }
+          ]
+        },
+        { "title": "前景理论", "depth": 0, "blocks": [{ "type": "text", "content": "损失带来的痛苦大于同等收益的快乐。" }] }
+      ]
+    },
+    {
+      "title": "《原则》",
+      "nodes": [
+        { "title": "极度求真", "depth": 0, "blocks": [{ "type": "text", "content": "面对现实，不自我欺骗。" }] },
+        { "title": "可信度加权", "depth": 0, "blocks": [{ "type": "text", "content": "决策时按可信度权重综合不同意见。" }] },
+        { "title": "五步流程", "depth": 0, "blocks": [{ "type": "text", "content": "目标 → 问题 → 诊断 → 设计 → 执行。" }] }
+      ]
+    }
+  ]
+}

--- a/Notte/Resources/SampleData/SwiftUILearning.json
+++ b/Notte/Resources/SampleData/SwiftUILearning.json
@@ -1,0 +1,67 @@
+{
+  "title": "SwiftUI 学习",
+  "iconName": "swift",
+  "colorToken": null,
+  "pages": [
+    {
+      "title": "SwiftUI 基础",
+      "nodes": [
+        {
+          "title": "什么是 SwiftUI",
+          "depth": 0,
+          "blocks": [
+            { "type": "text", "content": "Apple 推出的声明式 UI 框架，跨 iOS / iPadOS / macOS / watchOS / tvOS。" }
+          ],
+          "children": [
+            { "title": "声明式语法", "depth": 1, "blocks": [{ "type": "text", "content": "用 body 描述视图应该长什么样，而不是怎么变化。" }] },
+            { "title": "View 协议", "depth": 1, "blocks": [{ "type": "text", "content": "所有 View 都遵守 View 协议，必须提供 body。" }] }
+          ]
+        },
+        {
+          "title": "状态管理",
+          "depth": 0,
+          "children": [
+            { "title": "@State", "depth": 1, "blocks": [{ "type": "text", "content": "用于值类型的局部状态。" }] },
+            { "title": "@Binding", "depth": 1, "blocks": [{ "type": "text", "content": "双向绑定父视图传入的状态。" }] },
+            { "title": "@StateObject / @ObservedObject", "depth": 1, "blocks": [{ "type": "text", "content": "用于引用类型的可观察对象。" }] }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "布局系统",
+      "nodes": [
+        {
+          "title": "HStack / VStack / ZStack",
+          "depth": 0,
+          "blocks": [{ "type": "text", "content": "三种基础容器，决定子视图的排列方向。" }]
+        },
+        {
+          "title": "Spacer 与 Divider",
+          "depth": 0,
+          "blocks": [{ "type": "text", "content": "Spacer 填充剩余空间，Divider 在容器内自动绘制分隔线。" }]
+        },
+        {
+          "title": "frame 与 padding",
+          "depth": 0,
+          "blocks": [{ "type": "text", "content": "frame 设置尺寸约束，padding 添加内边距。" }]
+        }
+      ]
+    },
+    {
+      "title": "数据流",
+      "nodes": [
+        {
+          "title": "Environment 对象",
+          "depth": 0,
+          "blocks": [{ "type": "text", "content": "用于跨层级注入共享对象，避免参数透传。" }]
+        },
+        {
+          "title": "SwiftData 集成",
+          "depth": 0,
+          "blocks": [{ "type": "text", "content": "iOS 17+ 提供，与 SwiftUI 深度整合。" }]
+        }
+      ]
+    }
+  ]
+}

--- a/NotteTests/UnitTests/ExampleDataFactoryTests.swift
+++ b/NotteTests/UnitTests/ExampleDataFactoryTests.swift
@@ -1,0 +1,63 @@
+//
+//  ExampleDataFactoryTests.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/15.
+//
+
+import XCTest
+@testable import Notte
+
+@MainActor
+final class ExampleDataFactoryTests: XCTestCase {
+
+    var collectionRepository: MockCollectionRepository!
+    var pageRepository: MockPageRepository!
+    var nodeRepository: MockNodeRepository!
+    var blockRepository: MockBlockRepository!
+    var factory: ExampleDataFactory!
+
+    override func setUp() {
+        super.setUp()
+        collectionRepository = MockCollectionRepository()
+        pageRepository = MockPageRepository()
+        nodeRepository = MockNodeRepository()
+        blockRepository = MockBlockRepository()
+        factory = ExampleDataFactory(
+            collectionRepository: collectionRepository,
+            pageRepository: pageRepository,
+            nodeRepository: nodeRepository,
+            blockRepository: blockRepository
+        )
+    }
+
+    /// 测试：导入 SwiftUILearning 后 Collection 数量 +1，Page 与 Node 数量符合 JSON
+    func testImportSwiftUILearning() async throws {
+        try await factory.importOne(file: "SwiftUILearning")
+
+        XCTAssertEqual(collectionRepository.storedCollections.count, 1)
+        XCTAssertEqual(collectionRepository.storedCollections.first?.title, "SwiftUI 学习")
+        XCTAssertEqual(pageRepository.storedPages.count, 3)
+        XCTAssertGreaterThanOrEqual(nodeRepository.storedNodes.count, 12)
+    }
+
+    /// 测试：导入全部示例后三个 Collection 均存在且 sortIndex 互不冲突
+    func testImportAllProducesDistinctSortIndexes() async throws {
+        try await factory.importAll()
+        let sortIndexes = collectionRepository.storedCollections.map(\.sortIndex)
+        XCTAssertEqual(Set(sortIndexes).count, sortIndexes.count, "sortIndex 必须唯一")
+        XCTAssertEqual(collectionRepository.storedCollections.count, 3)
+    }
+
+    /// 测试：嵌套 Node 的 parentNodeID 指向同一 Page 内的父 Node
+    func testNestedNodesLinkToParent() async throws {
+        try await factory.importOne(file: "SwiftUILearning")
+        let nodes = nodeRepository.storedNodes
+        let childNodes = nodes.filter { $0.depth > 0 }
+        XCTAssertFalse(childNodes.isEmpty)
+        for child in childNodes {
+            XCTAssertNotNil(child.parentNodeID)
+            XCTAssertTrue(nodes.contains(where: { $0.id == child.parentNodeID }))
+        }
+    }
+}

--- a/NotteTests/UnitTests/OnboardingPersistenceTests.swift
+++ b/NotteTests/UnitTests/OnboardingPersistenceTests.swift
@@ -1,0 +1,36 @@
+//
+//  OnboardingPersistenceTests.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/15.
+//
+
+import XCTest
+@testable import Notte
+
+@MainActor
+final class OnboardingPersistenceTests: XCTestCase {
+
+    private let key = "hasCompletedOnboarding"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: key)
+        super.tearDown()
+    }
+
+    /// 测试：默认值为 false，首次启动需要展示引导
+    func testDefaultIsFalse() {
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: key))
+    }
+
+    /// 测试：写入 true 后跨实例读取保持为 true
+    func testFlagPersistsAcrossReads() {
+        UserDefaults.standard.set(true, forKey: key)
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: key))
+    }
+}

--- a/NotteTests/UnitTests/SettingsViewModelTests.swift
+++ b/NotteTests/UnitTests/SettingsViewModelTests.swift
@@ -1,0 +1,21 @@
+//
+//  SettingsViewModelTests.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/15.
+//
+
+import XCTest
+@testable import Notte
+
+@MainActor
+final class SettingsViewModelTests: XCTestCase {
+
+    /// 测试：版本号从 Bundle 读出后格式为 "<version> (<build>)"
+    func testAppVersionFormat() {
+        let vm = SettingsViewModel()
+        XCTAssertTrue(vm.appVersion.contains("("))
+        XCTAssertTrue(vm.appVersion.hasSuffix(")"))
+        XCTAssertFalse(vm.appVersion.contains("0.0.0 (0)"), "未读取到 Bundle 版本号")
+    }
+}


### PR DESCRIPTION
  ## 改动描述
                                                                                                                                      
  M6 里程碑：新用户引导 + 极简设置页，同时修复 node 展开/收起动画的遮挡 bug。                                                         
   
  **Onboarding**                                                                                                                      
  - 3 屏引导流（产品理念 → 核心模型 → 开始使用），含层级示意图组件 `OnboardingHierarchyIllustration`                                
  - 底部共用 CTA 栏，支持「下一步 / 完成」分栏与「跳过」                                                                              
  - 完成后跳转：创建第一个 Collection（直接唤起 sheet）或一键导入示例数据                                                             
  - `AppStorage` 记录首次运行标记，完成/跳过均不再展示引导                                                                            
  - 屏间切换使用 slide + spring 动画                                                                                                  
                                                                                                                                      
  **示例数据**                                                                                                                        
  - `ExampleDataFactory` 解析 JSON 并通过 Repository 层写入 SwiftData                                                                 
  - 3 份内置数据集：SwiftUI 学习笔记、项目规划、读书笔记                                                                              
                                                                                                                                      
  **Settings**                                                                                                                        
  - `SettingsView` 四个分区：iCloud 同步（M7 占位）、外观、关于（版本 / 反馈 / 隐私）、调试（重置引导 / 清除示例数据，仅 DEBUG）      
  - 主页入口通过 FAB 长按菜单或导航栏访问                                                                                             
                                                                                                                                      
  **UI / 交互修复**                                                                                                                   
  - FAB 提升至 `RootView` 层，避免导航转场时出现叠层动画                                                                              
  - FAB 与 settings 关闭按钮不再随键盘上移                                                                                            
  - Node 展开/收起：用 `depth` 固定 z-index 防止子 node 遮住父 node；`NodeRowView` 加 `minHeight(44)` 防止动画帧漏出到空内容的相邻    
  node 下方                                                                                                                           
                                                                                                                                      
  ## 关联 Issue                                                                                                                       
  Closes #                                                                                                                          
                                                                                                                                      
  ## 改动类型                                                                                                                       
  - [x] 新功能 (type/feature)
  - [x] Bug 修复 (type/bug)                                                                                                           
  - [x] 测试 (type/test)
  - [ ] 重构 (type/refactor)                                                                                                          
  - [ ] 文档 (type/docs)                                                                                                              
  - [ ] 构建/配置 (type/chore)
                                                                                                                                      
  ## 测试情况                                                                                                                       
  - [x] 新增了单元测试                                                                                                                
  - [x] 已在真机上验证                                                                                                              
  - [x] 已验证深色模式                                                                                                                
  - [ ] 已验证 iPhone SE 布局
                                                                                                                                      
  ## 截图（UI 改动时必填）                                                                                                            
  | Before | After |                                                                                                                  
  |--------|-------|                                                                                                                  
  |        |       |                                                                                                                
                                                                                                                                      
  ## 注意事项
  - `SettingsDebugSection` 仅在 `#if DEBUG` 编译条件下可见，无需担心线上暴露                                                          
  - `ExampleDataFactory` 导入是幂等的，重复调用不会产生重复数据（依赖 title 去重）                                                    
  - iCloud 同步分区为 M7 占位，点击无实际效果