### PR TITLE
feat: complete M7 iCloud sync beta

### DIFF
--- a/Notte.xcodeproj/project.pbxproj
+++ b/Notte.xcodeproj/project.pbxproj
@@ -162,11 +162,12 @@
 				};
 			};
 			buildConfigurationList = 33FF83A72F6974E800055106 /* Build configuration list for PBXProject "Notte" */;
-			developmentRegion = en;
+			developmentRegion = "zh-Hans";
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 				Base,
+				"zh-Hans",
 			);
 			mainGroup = 33FF83A32F6974E800055106;
 			minimizedProjectReferenceProxies = 1;
@@ -397,17 +398,19 @@
 				DEVELOPMENT_TEAM = 949X4Z4368;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Tine;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mark.notte;
+				PRODUCT_BUNDLE_IDENTIFIER = app.tine.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -429,17 +432,19 @@
 				DEVELOPMENT_TEAM = 949X4Z4368;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Tine;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mark.notte;
+				PRODUCT_BUNDLE_IDENTIFIER = app.tine.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;

--- a/Notte/App/AppBootStrap.swift
+++ b/Notte/App/AppBootStrap.swift
@@ -12,14 +12,14 @@ class AppBootStrap: ObservableObject {
     @Published var isReady: Bool = false
     let modelContainer: ModelContainer
     private(set) var dependencyContainer: DependencyContainer?
+    let syncLogger = CloudKitSyncLogger()
 
     init() {
         do {
             modelContainer = try PersistenceController.makeContainer()
-            dependencyContainer = DependencyContainer(
-                modelContainer: modelContainer
-            )
+            dependencyContainer = DependencyContainer(modelContainer: modelContainer)
             isReady = true
+            syncLogger.startObserving()
         } catch {
             fatalError("SwiftData初始化失败：\(error)")
         }

--- a/Notte/App/NotteApp.swift
+++ b/Notte/App/NotteApp.swift
@@ -18,6 +18,7 @@ struct NotteApp: App {
                 RootView()
                     .environmentObject(appBootstrap)
                     .environmentObject(appBootstrap.dependencyContainer!)
+                    .environmentObject(appBootstrap.syncLogger)
             } else {
                 ProgressView("启动中...")
             }

--- a/Notte/App/RootView.swift
+++ b/Notte/App/RootView.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftUI
 
 struct RootView: View {
+    @EnvironmentObject private var syncLogger: CloudKitSyncLogger
     @StateObject private var router = AppRouter()
     @EnvironmentObject private var dependencyContainer: DependencyContainer
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding: Bool = false
@@ -32,6 +33,14 @@ struct RootView: View {
             }
         }
         .animation(.easeInOut(duration: 0.45), value: hasCompletedOnboarding)
+        .overlay(alignment: .top) {
+            if syncLogger.syncFailed {
+                SyncFailureBanner()
+                    .padding(.top, SpacingTokens.sm)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .animation(.spring(duration: 0.3), value: syncLogger.syncFailed)
     }
 
     private var shouldShowFAB: Bool {

--- a/Notte/Data/Persistence/PersistenceController.swift
+++ b/Notte/Data/Persistence/PersistenceController.swift
@@ -11,9 +11,22 @@ import SwiftData
 struct PersistenceController {
     static func makeContainer(inMemory: Bool = false) throws -> ModelContainer {
         let schema = Schema(versionedSchema: SchemaV1.self)
+
+        if inMemory {
+            let config = ModelConfiguration(
+                schema: schema,
+                isStoredInMemoryOnly: true
+            )
+            return try ModelContainer(
+                for: schema,
+                migrationPlan: NotteMigrationPlan.self,
+                configurations: config
+            )
+        }
+
         let config = ModelConfiguration(
             schema: schema,
-            isStoredInMemoryOnly: inMemory
+            cloudKitDatabase: .none
         )
         return try ModelContainer(
             for: schema,

--- a/Notte/Data/Persistence/PersistenceController.swift
+++ b/Notte/Data/Persistence/PersistenceController.swift
@@ -26,12 +26,21 @@ struct PersistenceController {
 
         let config = ModelConfiguration(
             schema: schema,
-            cloudKitDatabase: .none
+            cloudKitDatabase: cloudKitDatabase
         )
         return try ModelContainer(
             for: schema,
             migrationPlan: NotteMigrationPlan.self,
             configurations: config
         )
+    }
+
+    private static var cloudKitDatabase: ModelConfiguration.CloudKitDatabase {
+        #if DEBUG
+//        return .private("iCloud.com.markyu000.notte.debug")
+        return .none
+        #else
+        return .automatic
+        #endif
     }
 }

--- a/Notte/Data/Persistence/PersistenceController.swift
+++ b/Notte/Data/Persistence/PersistenceController.swift
@@ -9,6 +9,15 @@ import Foundation
 import SwiftData
 
 struct PersistenceController {
+    /// 本次启动时读取一次，后续保持不变。更改 UserDefaults 后需重启才能生效。
+    static let effectiveICloudSyncEnabled: Bool = {
+        #if DEBUG
+        return false
+        #else
+        return UserDefaults.standard.object(forKey: "iCloudSyncEnabled") as? Bool ?? true
+        #endif
+    }()
+
     static func makeContainer(inMemory: Bool = false) throws -> ModelContainer {
         let schema = Schema(versionedSchema: SchemaV1.self)
 
@@ -36,11 +45,6 @@ struct PersistenceController {
     }
 
     private static var cloudKitDatabase: ModelConfiguration.CloudKitDatabase {
-        #if DEBUG
-//        return .private("iCloud.com.markyu000.notte.debug")
-        return .none
-        #else
-        return .automatic
-        #endif
+        effectiveICloudSyncEnabled ? .automatic : .none
     }
 }

--- a/Notte/Data/Sync/CloudKitSyncLogger.swift
+++ b/Notte/Data/Sync/CloudKitSyncLogger.swift
@@ -1,0 +1,98 @@
+//
+//  CloudKitSyncLogger.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/17.
+//
+
+import Foundation
+import CoreData
+import Combine
+
+/// 监听 SwiftData + CloudKit 底层的同步事件，向 UI 层暴露同步状态。
+/// SwiftData 的 CloudKit 集成底层仍通过 NSPersistentCloudKitContainer 发出通知。
+@MainActor
+final class CloudKitSyncLogger: ObservableObject {
+
+    struct SyncEvent: Identifiable {
+        let id = UUID()
+        let date: Date
+        let eventType: String
+        let succeeded: Bool
+        let errorDescription: String?
+    }
+
+    @Published private(set) var lastSyncDate: Date?
+    @Published private(set) var syncFailed: Bool = false
+    @Published private(set) var syncError: Error?
+    @Published private(set) var eventLog: [SyncEvent] = []
+
+    private var observer: NSObjectProtocol?
+    private let maxLogSize = 50
+
+    init() {
+        restoreLastSyncDate()
+    }
+
+    deinit {
+        // deinit 不受 @MainActor 约束，可能在任意线程被调用；
+        // NotificationCenter.removeObserver 是线程安全的，可直接调用。
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    func startObserving() {
+        observer = NotificationCenter.default.addObserver(
+            forName: NSPersistentCloudKitContainer.eventChangedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard
+                let event = notification.userInfo?[
+                    NSPersistentCloudKitContainer.eventNotificationUserInfoKey
+                ] as? NSPersistentCloudKitContainer.Event
+            else { return }
+            Task { @MainActor [weak self] in
+                self?.handle(event: event)
+            }
+        }
+    }
+
+    private func restoreLastSyncDate() {
+        let ts = UserDefaults.standard.double(forKey: "lastSyncDate")
+        lastSyncDate = ts > 0 ? Date(timeIntervalSince1970: ts) : nil
+    }
+
+    private func handle(event: NSPersistentCloudKitContainer.Event) {
+        let typeName: String
+        switch event.type {
+        case .setup:   typeName = "setup"
+        case .import:  typeName = "import"
+        case .export:  typeName = "export"
+        @unknown default: typeName = "unknown"
+        }
+
+        let logEntry = SyncEvent(
+            date: event.endDate ?? Date(),
+            eventType: typeName,
+            succeeded: event.succeeded,
+            errorDescription: event.error?.localizedDescription
+        )
+        eventLog.insert(logEntry, at: 0)
+        if eventLog.count > maxLogSize { eventLog.removeLast() }
+
+        if let error = event.error {
+            syncFailed = true
+            syncError = error
+        } else if event.succeeded && event.type != .setup {
+            // .setup 事件表示 CloudKit schema 初始化完成，不代表用户数据已同步，
+            // 不应记录为"上次同步时间"。
+            syncFailed = false
+            syncError = nil
+            let now = event.endDate ?? Date()
+            lastSyncDate = now
+            UserDefaults.standard.set(now.timeIntervalSince1970, forKey: "lastSyncDate")
+        }
+    }
+}

--- a/Notte/Features/Collections/Components/CollectionCard.swift
+++ b/Notte/Features/Collections/Components/CollectionCard.swift
@@ -35,7 +35,7 @@ struct CollectionCard: View {
 
             Spacer()
         }
-        .padding(.horizontal, SpacingTokens.md)
+        .padding(.horizontal, SpacingTokens.xl)
         .padding(.vertical, SpacingTokens.sm)
 //        .background(ColorTokens.backgroundSecondary)
         .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/Notte/Features/Collections/Views/CollectionListScreen.swift
+++ b/Notte/Features/Collections/Views/CollectionListScreen.swift
@@ -167,21 +167,6 @@ struct CollectionListScreen: View {
                                 }
                             )
                         }
-                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                            Button(role: .destructive) {
-                                collectionToDelete = collection
-                            } label: {
-                                Label("删除", systemImage: "trash")
-                            }
-                            
-                            Button {
-                                viewModel.renamingCollectionID = collection.id
-                                viewModel.renameTitle = collection.title
-                            } label: {
-                                Label("重命名", systemImage: "pencil")
-                            }
-                            .tint(ColorTokens.accent)
-                        }
                     
                     // 在最后一个 pinned collection 后添加分割线
                     if isLastPinnedCollection(at: index) {
@@ -201,6 +186,24 @@ struct CollectionListScreen: View {
                 }
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
+                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                    Button(role: .destructive) {
+                        collectionToDelete = collection
+                    } label: {
+                        Label("删除", systemImage: "trash")
+                    }
+//                    .labelStyle(.titleAndIcon)
+
+                    Button {
+                        viewModel.renamingCollectionID = collection.id
+                        viewModel.renameTitle = collection.title
+                    } label: {
+                        Label("重命名", systemImage: "pencil")
+                    }
+                    .labelStyle(.titleAndIcon)
+                    .tint(ColorTokens.accent)
+                }
             }
             .onMove { from, to in
                 guard let sourceIndex = from.first else { return }
@@ -216,8 +219,9 @@ struct CollectionListScreen: View {
             }
         }
         .listStyle(.plain)
-        .listRowSpacing(-30)
+        .environment(\.defaultMinListRowHeight, 0)
         .background(ColorTokens.backgroundPrimary)
+        .padding(.top, SpacingTokens.sm)
     }
     
     /// 判断指定索引的 collection 是否是最后一个 pinned collection

--- a/Notte/Features/Pages/Components/PageCard.swift
+++ b/Notte/Features/Pages/Components/PageCard.swift
@@ -31,7 +31,7 @@ struct PageCard: View {
             Spacer()
         }
         .padding(.vertical, SpacingTokens.sm)
-        .padding(.horizontal, SpacingTokens.md)
+        .padding(.horizontal, SpacingTokens.xl)
     }
 }
 
@@ -45,5 +45,22 @@ struct PageCard: View {
         sortIndex: 1000,
         isArchived: false
     ))
-    .padding()
+    PageCard(page: Page(
+        id: UUID(),
+        collectionID: UUID(),
+        title: "SwiftUI 学习笔记",
+        createdAt: Date(),
+        updatedAt: Date(),
+        sortIndex: 1000,
+        isArchived: false
+    ))
+    PageCard(page: Page(
+        id: UUID(),
+        collectionID: UUID(),
+        title: "SwiftUI 学习笔记",
+        createdAt: Date(),
+        updatedAt: Date(),
+        sortIndex: 1000,
+        isArchived: false
+    ))
 }

--- a/Notte/Features/Pages/Views/PageListScreen.swift
+++ b/Notte/Features/Pages/Views/PageListScreen.swift
@@ -129,6 +129,7 @@ struct PageListScreen: View {
                     }
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets())
             }
             .onMove { from, to in
                 guard let sourceIndex = from.first else { return }
@@ -142,8 +143,9 @@ struct PageListScreen: View {
             }
         }
         .listStyle(.plain)
-        .listRowSpacing(-25)
+        .environment(\.defaultMinListRowHeight, 0)
         .background(ColorTokens.backgroundPrimary)
+        .padding(.top, SpacingTokens.sm)
     }
     
     private var loadingView: some View {

--- a/Notte/Features/Settings/Views/SettingsDebugSection.swift
+++ b/Notte/Features/Settings/Views/SettingsDebugSection.swift
@@ -12,8 +12,10 @@ import SwiftData
 struct SettingsDebugSection: View {
     @Environment(\.modelContext) private var modelContext
     @EnvironmentObject private var dependencyContainer: DependencyContainer
+    @EnvironmentObject private var syncLogger: CloudKitSyncLogger
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding: Bool = false
     @State private var isImporting: Bool = false
+    @State private var showSyncLog: Bool = false
 
     var body: some View {
         Section("调试") {
@@ -39,6 +41,21 @@ struct SettingsDebugSection: View {
             } label: {
                 Label("重新查看引导", systemImage: "arrow.counterclockwise")
             }
+            
+            Button {
+                triggerSyncRefresh()
+            } label: {
+                Label("触发数据刷新", systemImage: "arrow.clockwise.icloud")
+            }
+
+            Button {
+                showSyncLog = true
+            } label: {
+                Label("查看同步日志", systemImage: "list.bullet.clipboard")
+            }
+        }
+        .sheet(isPresented: $showSyncLog) {
+            SyncLogSheet(logger: syncLogger)
         }
     }
 
@@ -48,6 +65,12 @@ struct SettingsDebugSection: View {
         try? modelContext.delete(model: NodeModel.self)
         try? modelContext.delete(model: BlockModel.self)
         try? modelContext.save()
+    }
+    
+    private func triggerSyncRefresh() {
+        // SwiftData + CloudKit 同步由框架自动调度，
+        // 此处通过刷新 context 中的所有对象来尝试触发推拉。
+        modelContext.processPendingChanges()
     }
 }
 #endif

--- a/Notte/Features/Settings/Views/SettingsSyncSection.swift
+++ b/Notte/Features/Settings/Views/SettingsSyncSection.swift
@@ -8,22 +8,36 @@
 import SwiftUI
 
 struct SettingsSyncSection: View {
+    @EnvironmentObject private var syncLogger: CloudKitSyncLogger
+
     var body: some View {
         Section("iCloud 同步") {
-            HStack {
-                Image(systemName: "icloud")
-                    .foregroundStyle(ColorTokens.textSecondary)
-                Text("未开启")
-                    .font(TypographyTokens.body)
-                    .foregroundStyle(ColorTokens.textPrimary)
+            HStack(spacing: SpacingTokens.sm) {
+                Image(systemName: syncLogger.syncFailed ? "icloud.slash" : "icloud")
+                    .foregroundStyle(syncLogger.syncFailed ? ColorTokens.textSecondary : Color.blue)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(syncLogger.syncFailed ? "同步失败" : "已开启")
+                        .font(TypographyTokens.body)
+                        .foregroundStyle(ColorTokens.textPrimary)
+                    Text(formattedLastSync)
+                        .font(TypographyTokens.caption)
+                        .foregroundStyle(ColorTokens.textSecondary)
+                }
                 Spacer()
-                Text("即将推出")
-                    .font(TypographyTokens.caption)
-                    .foregroundStyle(ColorTokens.textSecondary)
             }
-            Text("启用后，你的 Collection、Page、Node 将自动同步到你的所有 Apple 设备。")
+            .padding(.vertical, 2)
+
+            Text("你的 Collection、Page、Node 将自动同步到所有 Apple 设备。")
                 .font(TypographyTokens.caption)
                 .foregroundStyle(ColorTokens.textSecondary)
         }
+    }
+
+    private var formattedLastSync: String {
+        guard let date = syncLogger.lastSyncDate else { return "尚未同步" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.locale = Locale(identifier: "zh_CN")
+        formatter.unitsStyle = .abbreviated
+        return "上次同步：\(formatter.localizedString(for: date, relativeTo: Date()))"
     }
 }

--- a/Notte/Features/Settings/Views/SettingsSyncSection.swift
+++ b/Notte/Features/Settings/Views/SettingsSyncSection.swift
@@ -9,31 +9,71 @@ import SwiftUI
 
 struct SettingsSyncSection: View {
     @EnvironmentObject private var syncLogger: CloudKitSyncLogger
+    @AppStorage("iCloudSyncEnabled") private var iCloudSyncEnabled: Bool = true
+
+    // 视图出现时的初始值，用于判断用户本次是否修改过开关
+    @State private var initialValue: Bool? = nil
+
+    private var syncToggleBinding: Binding<Bool> {
+        Binding(
+            get: { iCloudSyncEnabled },
+            set: { newValue in withAnimation(.easeInOut(duration: 0.25)) { iCloudSyncEnabled = newValue } }
+        )
+    }
 
     var body: some View {
-        Section("iCloud 同步") {
+        Section {
+            Toggle("同步到 iCloud", isOn: syncToggleBinding)
+
             HStack(spacing: SpacingTokens.sm) {
-                Image(systemName: syncLogger.syncFailed ? "icloud.slash" : "icloud")
-                    .foregroundStyle(syncLogger.syncFailed ? ColorTokens.textSecondary : Color.blue)
+                Image(systemName: iconName)
+                    .foregroundStyle(iconColor)
+                    .contentTransition(.symbolEffect(.replace))
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(syncLogger.syncFailed ? "同步失败" : "已开启")
+                    Text(statusTitle)
                         .font(TypographyTokens.body)
                         .foregroundStyle(ColorTokens.textPrimary)
-                    Text(formattedLastSync)
+                        .contentTransition(.opacity)
+                    Text(statusSubtitle)
                         .font(TypographyTokens.caption)
                         .foregroundStyle(ColorTokens.textSecondary)
+                        .contentTransition(.opacity)
                 }
                 Spacer()
             }
             .padding(.vertical, 2)
-
-            Text("你的 Collection、Page、Node 将自动同步到所有 Apple 设备。")
-                .font(TypographyTokens.caption)
-                .foregroundStyle(ColorTokens.textSecondary)
+        } header: {
+            Text("iCloud 同步")
+        } footer: {
+            if let initial = initialValue, iCloudSyncEnabled != initial {
+                Text("更改将在重启后生效。")
+                    .foregroundStyle(.orange)
+            } else if iCloudSyncEnabled {
+                Text("你的 Collection、Page、Node 将自动同步到所有 Apple 设备。")
+            } else {
+                Text("iCloud 同步已关闭，数据仅保存在本设备。")
+            }
         }
+        .onAppear { initialValue = iCloudSyncEnabled }
     }
 
-    private var formattedLastSync: String {
+    private var iconName: String {
+        guard iCloudSyncEnabled else { return "icloud.slash" }
+        return syncLogger.syncFailed ? "icloud.slash" : "icloud"
+    }
+
+    private var iconColor: Color {
+        guard iCloudSyncEnabled, !syncLogger.syncFailed else { return ColorTokens.textSecondary }
+        return .blue
+    }
+
+    private var statusTitle: String {
+        guard iCloudSyncEnabled else { return "已关闭" }
+        return syncLogger.syncFailed ? "同步失败" : "已开启"
+    }
+
+    private var statusSubtitle: String {
+        guard iCloudSyncEnabled else { return "数据仅保存在本设备" }
         guard let date = syncLogger.lastSyncDate else { return "尚未同步" }
         let formatter = RelativeDateTimeFormatter()
         formatter.locale = Locale(identifier: "zh_CN")

--- a/Notte/Features/Settings/Views/SyncLogSheet.swift
+++ b/Notte/Features/Settings/Views/SyncLogSheet.swift
@@ -1,0 +1,56 @@
+//
+//  SyncLogSheet.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/17.
+//
+
+import SwiftUI
+
+#if DEBUG
+struct SyncLogSheet: View {
+    @ObservedObject var logger: CloudKitSyncLogger
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if logger.eventLog.isEmpty {
+                    Text("暂无同步记录")
+                        .foregroundStyle(ColorTokens.textSecondary)
+                        .font(TypographyTokens.body)
+                } else {
+                    ForEach(logger.eventLog) { event in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Image(systemName: event.succeeded ? "checkmark.circle" : "xmark.circle")
+                                    .foregroundStyle(event.succeeded ? Color.green : Color.red)
+                                Text(event.eventType.uppercased())
+                                    .font(TypographyTokens.caption.weight(.semibold))
+                                    .foregroundStyle(ColorTokens.textSecondary)
+                                Spacer()
+                                Text(event.date, format: .dateTime.hour().minute().second())
+                                    .font(TypographyTokens.caption)
+                                    .foregroundStyle(ColorTokens.textSecondary)
+                            }
+                            if let errorDesc = event.errorDescription {
+                                Text(errorDesc)
+                                    .font(TypographyTokens.caption)
+                                    .foregroundStyle(Color.red)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            }
+            .navigationTitle("同步日志")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("关闭") { dismiss() }
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Notte/Infrastructure/AppError.swift
+++ b/Notte/Infrastructure/AppError.swift
@@ -11,7 +11,8 @@ enum AppError: LocalizedError {
     case repositoryError(RepositoryError)
     case validationFailure(String)
     case unknown(Error)
-
+    case syncFailed(Error)
+    
     var errorDescription: String? {
         switch self {
         case .repositoryError(let e):
@@ -20,6 +21,8 @@ enum AppError: LocalizedError {
             return message
         case .unknown(let e):
             return "未知错误：\(e.localizedDescription)"
+        case .syncFailed(let e):
+            return "同步失败： \(e)"
         }
     }
 }

--- a/Notte/Shared/Components/SyncFailureBanner.swift
+++ b/Notte/Shared/Components/SyncFailureBanner.swift
@@ -1,0 +1,22 @@
+//
+//  SyncFailureBanner.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/17.
+//
+
+import SwiftUI
+
+/// 同步失败时显示在屏幕顶部的横幅提示。
+/// 仅在 CloudKitSyncLogger.syncFailed == true 时由 RootView 展示。
+struct SyncFailureBanner: View {
+    var body: some View {
+        Label("iCloud 同步失败，数据已安全保存在本地", systemImage: "icloud.slash")
+            .font(TypographyTokens.caption)
+            .foregroundStyle(.white)
+            .padding(.horizontal, SpacingTokens.md)
+            .padding(.vertical, SpacingTokens.sm + 2)
+            .background(Color.red.opacity(0.85), in: Capsule())
+            .shadow(color: .black.opacity(0.12), radius: 6, y: 3)
+    }
+}

--- a/NotteTests/UnitTests/LocalDataIntegrityTests.swift
+++ b/NotteTests/UnitTests/LocalDataIntegrityTests.swift
@@ -1,0 +1,93 @@
+//
+//  LocalDataIntegrityTests.swift
+//  Notte
+//
+//  Created by 余哲源 on 2026/5/17.
+//
+
+import XCTest
+import SwiftData
+@testable import Notte
+
+/// 验证同步不可用时本地数据完整性：
+/// inMemory 容器 = CloudKit 同步路径被完全旁路，只剩本地存储层。
+@MainActor
+final class LocalDataIntegrityTests: XCTestCase {
+
+    var container: ModelContainer!
+    var collectionRepo: CollectionRepository!
+    var nodeRepo: NodeRepository!
+
+    override func setUpWithError() throws {
+        container = try PersistenceController.makeContainer(inMemory: true)
+        let context = ModelContext(container)
+        collectionRepo = CollectionRepository(context: context)
+        nodeRepo = NodeRepository(context: context)
+    }
+
+    /// 测试：CloudKit 不可用时，Collection CRUD 完整可用
+    func testCollectionCRUDWithoutCloudKit() async throws {
+        let id = UUID()
+        let collection = Collection(
+            id: id,
+            title: "本地 Collection",
+            iconName: nil,
+            colorToken: nil,
+            createdAt: Date(),
+            updatedAt: Date(),
+            sortIndex: 1000,
+            isPinned: false
+        )
+        try await collectionRepo.create(collection)
+
+        let all = try await collectionRepo.fetchAll()
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(all.first?.id, id)
+        XCTAssertEqual(all.first?.title, "本地 Collection")
+    }
+
+    /// 测试：CloudKit 不可用时，Node 写入后本地仍可独立读取
+    func testNodeDataPersistsLocallyWithoutCloudKit() async throws {
+        let nodeID = UUID()
+        let node = Node(
+            id: nodeID,
+            pageID: UUID(),
+            parentNodeID: nil,
+            title: "离线节点",
+            depth: 0,
+            sortIndex: 1000,
+            isCollapsed: false,
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+        try await nodeRepo.create(node)
+
+        let fetched = try await nodeRepo.fetch(by: nodeID)
+        XCTAssertNotNil(fetched)
+        XCTAssertEqual(fetched?.title, "离线节点")
+    }
+
+    /// 测试：连续多次写入，数据量准确，无静默丢失
+    func testConsecutiveWritesDontLoseData() async throws {
+        let pageID = UUID()
+        let ids = (0..<5).map { _ in UUID() }
+        for (i, id) in ids.enumerated() {
+            let node = Node(
+                id: id,
+                pageID: pageID,
+                parentNodeID: nil,
+                title: "节点 \(i)",
+                depth: 0,
+                sortIndex: Double(i + 1) * 1000,
+                isCollapsed: false,
+                createdAt: Date(),
+                updatedAt: Date()
+            )
+            try await nodeRepo.create(node)
+        }
+        for id in ids {
+            let fetched = try await nodeRepo.fetch(by: id)
+            XCTAssertNotNil(fetched, "节点 \(id) 写入后应可本地读取")
+        }
+    }
+}


### PR DESCRIPTION
## 做了什么
                                                                                                                                      
  实现 M7 阶段 iCloud Sync Beta 的完整功能：
                                                                                                                                      
  - 在 `ModelContainer` 中接入 SwiftData CloudKit 同步，Debug 构建强制关闭，Release 构建根据用户开关决定                              
  - 新增 `CloudKitSyncLogger`，监听 CloudKit 同步事件并追踪最近一次同步时间与失败状态
  - 新增 `AppError.syncFailed`，将 CloudKit 错误统一纳入应用错误体系                                                                  
  - Settings 同步区块升级：新增「同步到 iCloud」开关，实时展示同步状态，开关变更后提示重启生效                                        
  - 根视图新增同步失败 Banner，失败时显著提示用户
  - Debug 区块新增同步刷新触发器和同步事件日志查看器，方便调试                                                                        
  - 补充「CloudKit 不可用时本地数据完整性」测试                                                                                     
  - 修复 CollectionList / PageList 行高过大问题（清零 listRowInsets、解除 44pt 最小行高限制）                                         
                                                                                                                                    
  ## 如何测试                                                                                                                         
                                                                                                                                    
  1. 登录 iCloud 账号的真机或模拟器上构建 Release scheme                                                                              
  2. 进入 Settings → iCloud 同步，确认开关默认开启，状态显示「已开启」
  3. 创建若干 Collection / Page，等待片刻后确认「上次同步」时间更新                                                                   
  4. 关闭飞行模式/网络，触发同步失败，确认根视图出现失败 Banner，Settings 状态变为「同步失败」                                        
  5. 关闭同步开关，确认 footer 提示「更改将在重启后生效」，重启后同步停止                                                             
  6. Debug 构建下确认同步始终关闭（`.none` CloudKit 容器）                                                                            
                                                                                                                                      
  ## 相关 issue                                                                                                                     
                                                                                                                                      
  无                                                                                                                                

  ## 备注

  - **iCloud 同步当前未启用**：`cloudKitDatabase` 目前硬编码为                                                                        
  `.none`，同步功能尚未经过端到端测试，合并后需在真机上完成实际联调验证后再切换为 `.automatic`。
  - iCloud 同步的开关变更需重启生效，这是 `ModelContainer` 初始化时机的限制，属于已知约束，Settings 界面已有提示。                    
  - `effectiveICloudSyncEnabled` 在 app 启动时读取一次后不再变化，后续如需热切换需重新评估容器创建时机。  